### PR TITLE
Fix the refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Updates the database with the latest data from Untappd.
 node --loader ts-node/esm scripts/update.ts
 ```
 
+## Refresh Breweries
+
+Refreshes the brewery data based on all checkins.
+
+```sh
+node --loader ts-node/esm scripts/refresh-breweries.ts
+```
+
 ### Tigris info
 
 Gets stats about the Tigris database.

--- a/scripts/refresh-breweries.ts
+++ b/scripts/refresh-breweries.ts
@@ -1,0 +1,18 @@
+/**
+ * This seed script will seed the Tigris database with the data from the `backup-2023.05.31.json`
+ * data files for checkins and user. Both these files are syncs of Untappd data accurate up to May
+ * 31, 2023 (it should be 5570 checkins total).
+ */
+
+/* eslint-disable no-console */
+
+import { TigrisClient } from '../src/lib/index.js';
+
+(async () => {
+  const tigris = await TigrisClient.create();
+  try {
+    await tigris.updateBreweries();
+  } catch (error) {
+    console.error('[Error]', error);
+  }
+})();

--- a/src/components/CheckinPlacard.svelte
+++ b/src/components/CheckinPlacard.svelte
@@ -5,7 +5,7 @@
 
   export let checkin: Checkin;
 
-  const ratingClasses = new Array(5).fill('').map((v, i) => {
+  $: ratingClasses = new Array(5).fill('').map((v, i) => {
     const diff = checkin.rating - i;
     return diff >= 1
       ? 'fill'

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -55,6 +55,8 @@
       setTimeout(() => (refreshStatus = ''), 2000);
     } catch (error) {
       console.error('There was a problem fetching the data.', error);
+      refreshStatus = `There was a problem fetching the data.`;
+      setTimeout(() => (refreshStatus = ''), 2000);
     }
 
     refreshButtonText = 'Refresh';

--- a/src/lib/TigrisClient.ts
+++ b/src/lib/TigrisClient.ts
@@ -190,11 +190,16 @@ export default class TigrisClient {
     }
 
     if (newCheckins) {
-      const breweriesWithUpdates = await this.breweryCollection.findMany({
-        filter: {
-          $or: Object.keys(breweryMap).map(brewerySlug => ({ slug: brewerySlug })),
-        },
-      });
+      const filter =
+        Object.keys(breweryMap).length > 1
+          ? {
+              $or: Object.keys(breweryMap).map(brewerySlug => ({ slug: brewerySlug })),
+            }
+          : {
+              slug: Object.keys(breweryMap)[0],
+            };
+
+      const breweriesWithUpdates = await this.breweryCollection.findMany({ filter });
 
       for await (const brewery of breweriesWithUpdates) {
         if (breweryMap[brewery.slug]) {


### PR DESCRIPTION
- Makes the rating rendering of a checkin reactive to fix a big where ratings weren't getting updated in checkin placards on refresh of data.
- Fixes a bug where Tigris wasn't updating brewery records on refreshes for only a singular brewery since the `$or` filter syntax is incorrect with only a singular condition.
- Adds a node script to refresh brewery records.